### PR TITLE
Fixed issue on reading binary of image

### DIFF
--- a/static_file.py
+++ b/static_file.py
@@ -197,7 +197,8 @@ class NereidStaticFile:
         :param filename: The file to which the transformed image
                          needs to be written
         """
-        image_file = Image.open(BytesIO(self.file_binary))
+        # Ugly hack '[:]' to fix issue in python 2.7.3
+        image_file = Image.open(BytesIO(self.file_binary[:]))
 
         parse_command = TransformationCommand.parse_command
 


### PR DESCRIPTION
Issue in python 2.7.3 with BytesIO on reading file_binary buffer
