### PR TITLE
abort(404) if operation type not allowed

### DIFF
--- a/static_file.py
+++ b/static_file.py
@@ -217,7 +217,8 @@ class NereidStaticFile:
 
         for command in commands.split('/'):
             operation, params = parse_command(command)
-            assert operation in self.allowed_operations
+            if operation not in self.allowed_operations:
+                abort(404)
             image_file = getattr(self, operation)(image_file, **params)
 
         image_file.save(filename)


### PR DESCRIPTION
If operation provided in the url is not in allowed list, then url is
actually invalid and hence abort 404.
